### PR TITLE
Refactor: Implement pure MVVM architecture for DLL information control

### DIFF
--- a/Controls/DllInformationControl.xaml
+++ b/Controls/DllInformationControl.xaml
@@ -1,0 +1,45 @@
+<UserControl x:Class="OneNoteAddinManager.Controls.DllInformationControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             mc:Ignorable="d" 
+             d:DesignHeight="200" d:DesignWidth="600">
+    <Border Background="#F8F8F8" 
+            Padding="15" 
+            CornerRadius="5"
+            BorderBrush="#E0E0E0"
+            BorderThickness="1">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="120"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            
+            <TextBlock Grid.Row="0" Grid.Column="0" Text="File Exists:" FontWeight="Bold"/>
+            <TextBlock Grid.Row="0" Grid.Column="1" 
+                       Text="{Binding FileExistsText}" 
+                       Foreground="{Binding FileExistsBrush}"/>
+            
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="File Locked:" FontWeight="Bold"/>
+            <TextBlock Grid.Row="1" Grid.Column="1" 
+                       Text="{Binding FileLockedText}"
+                       Foreground="{Binding FileLockedBrush}"
+                       ToolTip="{Binding LockDetails}"/>
+            
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="File Size:" FontWeight="Bold"/>
+            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding FileSizeText}"/>
+            
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="Last Modified:" FontWeight="Bold"/>
+            <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding LastModifiedText}"/>
+        </Grid>
+    </Border>
+</UserControl>

--- a/Controls/DllInformationControl.xaml.cs
+++ b/Controls/DllInformationControl.xaml.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using OneNoteAddinManager.ViewModels;
+
+namespace OneNoteAddinManager.Controls
+{
+    /// <summary>
+    /// Pure View - contains NO business logic, only UI structure and ViewModel binding
+    /// </summary>
+    public partial class DllInformationControl : UserControl
+    {
+        private DllInfoViewModel? _viewModel;
+
+        public DllInformationControl()
+        {
+            InitializeComponent();
+            
+            // Start with no file selected (null)
+            UpdateViewModel(null);
+            
+            // Clean up ViewModel when control is unloaded
+            this.Unloaded += DllInformationControl_Unloaded;
+        }
+
+        private void UpdateViewModel(string? dllPath)
+        {
+            // Dispose old ViewModel
+            _viewModel?.Dispose();
+            
+            // Create new ViewModel for the new path (null = no file)
+            _viewModel = new DllInfoViewModel(dllPath);
+            this.DataContext = _viewModel;
+        }
+
+        // ONLY public interface - everything else is handled by ViewModel
+        public static readonly DependencyProperty DllPathProperty =
+            DependencyProperty.Register("DllPath", typeof(string), typeof(DllInformationControl),
+                new PropertyMetadata(null, OnDllPathChanged));
+
+        public string? DllPath
+        {
+            get => (string?)GetValue(DllPathProperty);
+            set => SetValue(DllPathProperty, value);
+        }
+
+        private static void OnDllPathChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var control = (DllInformationControl)d;
+            // Create new ViewModel instance for new path (handle null properly)
+            var newPath = e.NewValue as string;
+            control.UpdateViewModel(string.IsNullOrEmpty(newPath) ? null : newPath);
+        }
+
+        private void DllInformationControl_Unloaded(object sender, RoutedEventArgs e)
+        {
+            // Clean up ViewModel
+            _viewModel?.Dispose();
+        }
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -4,6 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:OneNoteAddinManager"
+        xmlns:controls="clr-namespace:OneNoteAddinManager.Controls"
         mc:Ignorable="d"
         Title="OneNote Add-in Manager"
         Height="600"
@@ -381,39 +382,7 @@
                                                FontWeight="Bold" 
                                                Margin="0,0,0,10"/>
                                     
-                                    <Border Background="#F8F8F8" 
-                                            Padding="15" 
-                                            Margin="0,0,0,20" 
-                                            CornerRadius="5"
-                                            BorderBrush="#E0E0E0"
-                                            BorderThickness="1">
-                                        <Grid>
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="120"/>
-                                                <ColumnDefinition Width="*"/>
-                                                <ColumnDefinition Width="Auto"/>
-                                            </Grid.ColumnDefinitions>
-                                            <Grid.RowDefinitions>
-                                                <RowDefinition Height="Auto"/>
-                                                <RowDefinition Height="Auto"/>
-                                                <RowDefinition Height="Auto"/>
-                                                <RowDefinition Height="Auto"/>
-                                                <RowDefinition Height="Auto"/>
-                                            </Grid.RowDefinitions>
-                                            
-                                            <TextBlock Grid.Row="0" Grid.Column="0" Text="File Exists:" FontWeight="Bold"/>
-                                            <TextBlock Grid.Row="0" Grid.Column="1" x:Name="DllExistsText"/>
-                                            
-                                            <TextBlock Grid.Row="1" Grid.Column="0" Text="File Locked:" FontWeight="Bold"/>
-                                            <TextBlock Grid.Row="1" Grid.Column="1" x:Name="DllLockedText"/>
-                                            
-                                            <TextBlock Grid.Row="2" Grid.Column="0" Text="File Size:" FontWeight="Bold"/>
-                                            <TextBlock Grid.Row="2" Grid.Column="1" x:Name="DllSizeText"/>
-                                            
-                                            <TextBlock Grid.Row="3" Grid.Column="0" Text="Last Modified:" FontWeight="Bold"/>
-                                            <TextBlock Grid.Row="3" Grid.Column="1" x:Name="DllModifiedText"/>
-                                        </Grid>
-                                    </Border>
+                                    <controls:DllInformationControl x:Name="DllInfoControl" Margin="0,0,0,20"/>
 
                                 </StackPanel>
                             </ScrollViewer>

--- a/ViewModels/DllInfoViewModel.cs
+++ b/ViewModels/DllInfoViewModel.cs
@@ -1,0 +1,214 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Windows.Media;
+using OneNoteAddinManager.Models;
+
+namespace OneNoteAddinManager.ViewModels
+{
+    /// <summary>
+    /// ViewModel for DLL information - contains ALL presentation logic
+    /// </summary>
+    public class DllInfoViewModel : INotifyPropertyChanged
+    {
+        private readonly FileInfo? _assemblyFile;
+        private readonly string? _assemblyPath;
+        private System.Windows.Threading.DispatcherTimer? _lockStatusTimer;
+        
+        // ViewModel-specific state (not part of the immutable model)
+        private bool _isLocked = false;
+        private string _lockDetails = string.Empty;
+
+        public DllInfoViewModel(string? assemblyPath)
+        {
+            _assemblyPath = assemblyPath;
+            
+            // Create FileInfo only if we have a valid path
+            if (assemblyPath != null)
+            {
+                _assemblyFile = new FileInfo(assemblyPath);
+                
+                // Initialize lock status
+                if (_assemblyFile.Exists)
+                {
+                    var (isLocked, details) = CheckFileLock(assemblyPath);
+                    _isLocked = isLocked;
+                    _lockDetails = details;
+                }
+            }
+            
+            // Set up periodic lock status checking
+            _lockStatusTimer = new System.Windows.Threading.DispatcherTimer
+            {
+                Interval = TimeSpan.FromSeconds(2)
+            };
+            _lockStatusTimer.Tick += (s, e) => UpdateLockStatusIfNeeded();
+            _lockStatusTimer.Start();
+        }
+
+        // Read-only properties based on FileInfo
+
+        // ViewModel-managed lock state (separate from immutable model)
+        public bool IsLocked
+        {
+            get => _isLocked;
+            private set
+            {
+                if (_isLocked != value)
+                {
+                    _isLocked = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(FileLockedText));
+                    OnPropertyChanged(nameof(FileLockedBrush));
+                }
+            }
+        }
+
+        public string LockDetails
+        {
+            get => _lockDetails;
+            private set
+            {
+                if (_lockDetails != value)
+                {
+                    _lockDetails = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        // Computed properties for presentation
+        public string FileExistsText
+        {
+            get
+            {
+                if (_assemblyFile?.Exists != true) return "❌ No";
+                return "✓ Yes";
+            }
+        }
+
+        public Brush FileExistsBrush
+        {
+            get
+            {
+                if (_assemblyFile?.Exists != true) return Brushes.Red;
+                return Brushes.Green;
+            }
+        }
+
+        public string FileSizeText
+        {
+            get
+            {
+                if (_assemblyFile?.Exists != true) return "N/A";
+                return FormatFileSize(_assemblyFile.Length);
+            }
+        }
+
+        public string FileLockedText
+        {
+            get
+            {
+                if (_assemblyFile?.Exists != true) return "N/A";
+                return IsLocked ? "🔒 Yes" : "🔓 No";
+            }
+        }
+
+        public Brush FileLockedBrush
+        {
+            get
+            {
+                if (_assemblyFile?.Exists != true) return Brushes.Gray;
+                return IsLocked ? Brushes.Red : Brushes.Green;
+            }
+        }
+
+        public string LastModifiedText
+        {
+            get
+            {
+                if (_assemblyFile?.Exists != true) return "N/A";
+                return _assemblyFile.LastWriteTime.ToString("yyyy-MM-dd HH:mm:ss");
+            }
+        }
+
+
+        // No UpdateFromPath method - path is immutable after construction!
+
+        private void UpdateLockStatusIfNeeded()
+        {
+            if (_assemblyPath == null || _assemblyFile?.Exists != true)
+                return;
+
+            try
+            {
+                var (isLocked, details) = CheckFileLock(_assemblyPath);
+                
+                // Only update if lock status actually changed
+                if (IsLocked != isLocked)
+                {
+                    IsLocked = isLocked;
+                    LockDetails = details;
+                }
+            }
+            catch (Exception)
+            {
+                // Ignore errors during lock status updates
+            }
+        }
+
+        private (bool IsLocked, string Details) CheckFileLock(string filePath)
+        {
+            try
+            {
+                using (var stream = File.Open(filePath, FileMode.Open, FileAccess.Write, FileShare.None))
+                {
+                    return (false, "File is not locked - available for writing");
+                }
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return (true, "File is locked - access denied (may be in use by OneNote or another process)");
+            }
+            catch (IOException ex)
+            {
+                if (ex.Message.Contains("being used by another process"))
+                {
+                    return (true, "File is locked - currently being used by another process (likely OneNote)");
+                }
+                return (true, $"File is locked - {ex.Message}");
+            }
+            catch (Exception ex)
+            {
+                return (false, $"Could not determine lock status: {ex.Message}");
+            }
+        }
+
+        private string FormatFileSize(long bytes)
+        {
+            string[] suffixes = { "B", "KB", "MB", "GB", "TB" };
+            int counter = 0;
+            decimal number = bytes;
+            while (Math.Round(number / 1024) >= 1)
+            {
+                number /= 1024;
+                counter++;
+            }
+            return $"{number:n1} {suffixes[counter]}";
+        }
+
+        public void Dispose()
+        {
+            _lockStatusTimer?.Stop();
+            _lockStatusTimer = null;
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}


### PR DESCRIPTION
- Extract DLL information display into reusable DllInformationControl component
- Implement proper MVVM separation with immutable ViewModel instances
- Replace custom DllFileInfo model with built-in .NET FileInfo class
- Move lock detection logic from MainWindow into self-managing control
- Use constructor-only ViewModel pattern - each instance represents one assembly path
- Control creates new ViewModel instance on path changes for true immutability
- Support null assembly paths with proper semantic meaning (no file vs empty path)
- Remove direct UI manipulation in favor of data binding throughout
- Eliminate coupling between OneNote process events and DLL lock detection

The control now has a minimal public interface (DllPath property only) while internally managing all presentation logic, file monitoring, and lock status detection. This improves maintainability and follows WPF best practices.