### PR TITLE
Refactor right rail into DocumentationViewerControl using MVVM patterns

### DIFF
--- a/Controls/DocumentationViewerControl.xaml
+++ b/Controls/DocumentationViewerControl.xaml
@@ -1,0 +1,30 @@
+<UserControl x:Class="OneNoteAddinManager.Controls.DocumentationViewerControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="400">
+    <Grid>
+        <GroupBox Header="Context Help" Margin="5" Padding="10">
+            <Grid>
+                <!-- Documentation Content -->
+                <ScrollViewer 
+                              VerticalScrollBarVisibility="Auto" 
+                              HorizontalScrollBarVisibility="Disabled"
+                              Background="White"
+                              BorderBrush="LightGray"
+                              BorderThickness="1"
+                              Padding="10">
+                    <ItemsControl ItemsSource="{Binding MarkdownContent}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                    </ItemsControl>
+                </ScrollViewer>
+            </Grid>
+        </GroupBox>
+    </Grid>
+</UserControl>

--- a/Controls/DocumentationViewerControl.xaml.cs
+++ b/Controls/DocumentationViewerControl.xaml.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using OneNoteAddinManager.ViewModels;
+
+namespace OneNoteAddinManager.Controls
+{
+    public partial class DocumentationViewerControl : UserControl
+    {
+        public static readonly DependencyProperty DocumentIdProperty =
+            DependencyProperty.Register("DocumentId", typeof(string), typeof(DocumentationViewerControl),
+                new PropertyMetadata(null, OnDocumentIdChanged));
+
+        public event EventHandler<string>? DocumentChanged;
+
+        private DocumentationViewerViewModel _viewModel;
+
+        public DocumentationViewerControl()
+        {
+            InitializeComponent();
+            _viewModel = new DocumentationViewerViewModel();
+            _viewModel.DocumentChanged += (sender, documentId) => DocumentChanged?.Invoke(this, documentId);
+            DataContext = _viewModel;
+            Unloaded += DocumentationViewerControl_Unloaded;
+        }
+
+        public string? DocumentId
+        {
+            get => (string?)GetValue(DocumentIdProperty);
+            set => SetValue(DocumentIdProperty, value);
+        }
+
+        private static void OnDocumentIdChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is DocumentationViewerControl control && control._viewModel != null)
+            {
+                control._viewModel.CurrentDocumentId = e.NewValue as string;
+            }
+        }
+
+
+        private void DocumentationViewerControl_Unloaded(object sender, RoutedEventArgs e)
+        {
+            _viewModel?.Dispose();
+        }
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -333,52 +333,10 @@
                           Background="LightGray" 
                           ShowsPreview="True"/>
 
-            <!-- Right Rail - Context Help -->
-            <GroupBox Grid.Column="3" 
-                      Header="Context Help">
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                    </Grid.RowDefinitions>
-                    
-                    <!-- Quick Reference Links -->
-                    <StackPanel Grid.Row="0" 
-                                Orientation="Horizontal" 
-                                Margin="0,0,0,10">
-                        <Button x:Name="OverviewLinkButton"
-                                Content="Overview"
-                                Click="OverviewLinkButton_Click"
-                                Padding="8,4"
-                                Margin="0,0,5,0"/>
-                        <Button x:Name="FieldsLinkButton"
-                                Content="Fields"
-                                Click="FieldsLinkButton_Click"
-                                Padding="8,4"
-                                Margin="0,0,5,0"/>
-                        <Button x:Name="TroubleshootingLinkButton"
-                                Content="Troubleshooting"
-                                Click="TroubleshootingLinkButton_Click"
-                                Padding="8,4"/>
-                    </StackPanel>
-                    
-                    <!-- Dynamic Markdown Viewer -->
-                    <ScrollViewer Grid.Row="1" 
-                                  VerticalScrollBarVisibility="Auto"
-                                  HorizontalScrollBarVisibility="Disabled"
-                                  Background="White"
-                                  BorderBrush="LightGray" 
-                                  BorderThickness="1">
-                        <StackPanel x:Name="MarkdownContent" 
-                                    Margin="15"
-                                    Background="White">
-                            <TextBlock Text="Loading context help..." 
-                                       FontFamily="Segoe UI" 
-                                       FontSize="12"/>
-                        </StackPanel>
-                    </ScrollViewer>
-                </Grid>
-            </GroupBox>
+            <!-- Right Rail - Documentation Viewer -->
+            <controls:DocumentationViewerControl x:Name="DocumentationViewer"
+                                                 Grid.Column="3"
+                                                 DocumentChanged="DocumentationViewer_DocumentChanged"/>
         </Grid>
 
         <!-- Status Bar -->

--- a/ViewModels/DocumentationViewerViewModel.cs
+++ b/ViewModels/DocumentationViewerViewModel.cs
@@ -1,0 +1,315 @@
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Media;
+
+namespace OneNoteAddinManager.ViewModels
+{
+    public class DocumentationViewerViewModel : INotifyPropertyChanged, IDisposable
+    {
+        private string? _currentDocumentId;
+        private ObservableCollection<UIElement> _markdownContent;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        public event EventHandler<string>? DocumentChanged;
+
+        public DocumentationViewerViewModel()
+        {
+            _markdownContent = new ObservableCollection<UIElement>();
+        }
+
+        public string? CurrentDocumentId
+        {
+            get => _currentDocumentId;
+            set
+            {
+                if (_currentDocumentId != value)
+                {
+                    _currentDocumentId = value;
+                    OnPropertyChanged();
+                    LoadDocumentation(value);
+                    if (value != null)
+                    {
+                        DocumentChanged?.Invoke(this, value);
+                    }
+                }
+            }
+        }
+
+        public ObservableCollection<UIElement> MarkdownContent
+        {
+            get => _markdownContent;
+            private set
+            {
+                _markdownContent = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private void LoadDocumentation(string? topic)
+        {
+            if (string.IsNullOrEmpty(topic))
+            {
+                MarkdownContent.Clear();
+                return;
+            }
+
+            try
+            {
+                var resourceName = $"OneNoteAddinManager.Documentation.{topic}.md";
+                var assembly = Assembly.GetExecutingAssembly();
+
+                using var stream = assembly.GetManifestResourceStream(resourceName);
+                if (stream == null)
+                {
+                    // Fallback to file system
+                    var filePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Documentation", $"{topic}.md");
+                    if (File.Exists(filePath))
+                    {
+                        var content = File.ReadAllText(filePath);
+                        DisplaySimpleMarkdown(content);
+                    }
+                    else
+                    {
+                        ShowErrorMessage($"Documentation for '{topic}' not found.");
+                    }
+                    return;
+                }
+
+                using var reader = new StreamReader(stream);
+                var markdownContent = reader.ReadToEnd();
+                DisplaySimpleMarkdown(markdownContent);
+            }
+            catch (Exception ex)
+            {
+                ShowErrorMessage($"Error loading documentation: {ex.Message}");
+            }
+        }
+
+        private void ShowErrorMessage(string message)
+        {
+            MarkdownContent.Clear();
+            MarkdownContent.Add(new TextBlock
+            {
+                Text = message,
+                FontFamily = new FontFamily("Segoe UI"),
+                FontSize = 12,
+                Foreground = Brushes.Red
+            });
+        }
+
+        private void DisplaySimpleMarkdown(string markdownContent)
+        {
+            MarkdownContent.Clear();
+
+            var lines = markdownContent.Split('\n');
+            var currentParagraph = new StringBuilder();
+
+            foreach (var line in lines)
+            {
+                var trimmedLine = line.TrimEnd();
+
+                if (string.IsNullOrWhiteSpace(trimmedLine))
+                {
+                    // End current paragraph if it has content
+                    if (currentParagraph.Length > 0)
+                    {
+                        AddParagraph(currentParagraph.ToString());
+                        currentParagraph.Clear();
+                    }
+                    continue;
+                }
+
+                // Headers
+                if (trimmedLine.StartsWith("# "))
+                {
+                    // Finish current paragraph first
+                    if (currentParagraph.Length > 0)
+                    {
+                        AddParagraph(currentParagraph.ToString());
+                        currentParagraph.Clear();
+                    }
+
+                    AddHeader1(trimmedLine.Substring(2));
+                    continue;
+                }
+
+                if (trimmedLine.StartsWith("## "))
+                {
+                    if (currentParagraph.Length > 0)
+                    {
+                        AddParagraph(currentParagraph.ToString());
+                        currentParagraph.Clear();
+                    }
+
+                    AddHeader2(trimmedLine.Substring(3));
+                    continue;
+                }
+
+                if (trimmedLine.StartsWith("### "))
+                {
+                    if (currentParagraph.Length > 0)
+                    {
+                        AddParagraph(currentParagraph.ToString());
+                        currentParagraph.Clear();
+                    }
+
+                    AddHeader3(trimmedLine.Substring(4));
+                    continue;
+                }
+
+                // List items
+                if (trimmedLine.StartsWith("- ") || trimmedLine.StartsWith("* "))
+                {
+                    if (currentParagraph.Length > 0)
+                    {
+                        AddParagraph(currentParagraph.ToString());
+                        currentParagraph.Clear();
+                    }
+
+                    AddListItem(trimmedLine.Substring(2));
+                    continue;
+                }
+
+                // Code blocks (simple detection)
+                if (trimmedLine.StartsWith("```"))
+                {
+                    continue; // Skip markdown code fences
+                }
+
+                // Regular paragraph text
+                if (currentParagraph.Length > 0)
+                {
+                    currentParagraph.Append(" ");
+                }
+                currentParagraph.Append(ProcessBoldText(trimmedLine));
+            }
+
+            // Add final paragraph if exists
+            if (currentParagraph.Length > 0)
+            {
+                AddParagraph(currentParagraph.ToString());
+            }
+        }
+
+        private void AddHeader1(string text)
+        {
+            var textBlock = new TextBlock
+            {
+                Text = text,
+                FontSize = 20,
+                FontWeight = FontWeights.Bold,
+                Foreground = new SolidColorBrush(Color.FromRgb(0x2B, 0x57, 0x9A)),
+                Margin = new Thickness(0, 15, 0, 10),
+                TextWrapping = TextWrapping.Wrap
+            };
+            MarkdownContent.Add(textBlock);
+        }
+
+        private void AddHeader2(string text)
+        {
+            var textBlock = new TextBlock
+            {
+                Text = text,
+                FontSize = 16,
+                FontWeight = FontWeights.Bold,
+                Foreground = new SolidColorBrush(Color.FromRgb(0x2B, 0x57, 0x9A)),
+                Margin = new Thickness(0, 12, 0, 8),
+                TextWrapping = TextWrapping.Wrap
+            };
+            MarkdownContent.Add(textBlock);
+        }
+
+        private void AddHeader3(string text)
+        {
+            var textBlock = new TextBlock
+            {
+                Text = text,
+                FontSize = 14,
+                FontWeight = FontWeights.Bold,
+                Foreground = new SolidColorBrush(Color.FromRgb(0x33, 0x33, 0x33)),
+                Margin = new Thickness(0, 10, 0, 6),
+                TextWrapping = TextWrapping.Wrap
+            };
+            MarkdownContent.Add(textBlock);
+        }
+
+        private void AddListItem(string text)
+        {
+            var textBlock = new TextBlock
+            {
+                Text = "• " + ProcessBoldText(text),
+                FontSize = 12,
+                Margin = new Thickness(20, 2, 0, 2),
+                TextWrapping = TextWrapping.Wrap,
+                FontFamily = new FontFamily("Segoe UI")
+            };
+            MarkdownContent.Add(textBlock);
+        }
+
+        private void AddParagraph(string text)
+        {
+            if (string.IsNullOrWhiteSpace(text)) return;
+
+            var textBlock = new TextBlock
+            {
+                FontSize = 12,
+                Margin = new Thickness(0, 0, 0, 8),
+                TextWrapping = TextWrapping.Wrap,
+                FontFamily = new FontFamily("Segoe UI"),
+                LineHeight = 18
+            };
+
+            // Process bold formatting
+            ProcessBoldInlines(textBlock, text);
+
+            MarkdownContent.Add(textBlock);
+        }
+
+        private string ProcessBoldText(string text)
+        {
+            // Simple bold removal for plain text scenarios
+            return text.Replace("**", "");
+        }
+
+        private void ProcessBoldInlines(TextBlock textBlock, string text)
+        {
+            var parts = text.Split(new[] { "**" }, StringSplitOptions.None);
+            bool isBold = false;
+
+            foreach (var part in parts)
+            {
+                if (string.IsNullOrEmpty(part))
+                {
+                    isBold = !isBold;
+                    continue;
+                }
+
+                var run = new Run(part);
+                if (isBold)
+                {
+                    run.FontWeight = FontWeights.Bold;
+                }
+
+                textBlock.Inlines.Add(run);
+                isBold = !isBold;
+            }
+        }
+
+        protected virtual void OnPropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string? propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        public void Dispose()
+        {
+            MarkdownContent?.Clear();
+        }
+    }
+}


### PR DESCRIPTION
Extract documentation display functionality from MainWindow into a reusable WPF UserControl following established MVVM patterns. The new DocumentationViewerControl encapsulates all markdown rendering logic and provides a clean interface through dependency properties and events.

Changes:
- Add DocumentationViewerControl with MVVM binding to MarkdownContent
- Add DocumentationViewerViewModel with self-contained documentation loading logic
- Remove 250+ lines of documentation code from MainWindow
- Replace inline markup with ItemsControl data binding
- Add DocumentId dependency property and DocumentChanged event
- Remove Quick Reference Links buttons
- Update all documentation loading calls to use new control

Benefits:
- Improved separation of concerns following existing UserControl patterns
- Self-contained documentation functionality
- Reusable component with clean interface
- Proper resource management with IDisposable